### PR TITLE
Integrate GitHub Actions to validate notebooks 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,28 @@
+name: Test
+
+on: push
+
+jobs:
+    validate-notebooks:
+      name: Validate Notebooks
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+        - name: Setup Conda Environment
+          uses: conda-incubator/setup-miniconda@v2
+          with:
+            activate-environment: uc-python
+            environment-file: environment.yml
+        - name: Install nbconvert
+          shell: bash -l {0}
+          run:
+            conda install -y nbconvert
+        - name: Convert notebooks to scripts
+          shell: bash -l {0}
+          run: 
+            bash scripts/generate_scripts.sh
+        - name: Run scripts
+          shell: bash -l {0}
+          run:
+            bash scripts/test_nb_scripts.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,12 +3,12 @@ name: Test
 on: push
 
 jobs:
-  setup:
-    name: setup
+  validate-notebooks:
+    name: Validate Notebooks
     runs-on: ubuntu-latest
     defaults:
       run:
-        # Required for commands to execute *within the conda env*
+        # Required for "run" commands to execute in the conda env.
         shell: bash -l {0}
     steps:
       - name: Checkout Code
@@ -30,14 +30,6 @@ jobs:
           for nb in notebooks/*.ipynb; do
             python scripts/prep_nb_for_ci.py $nb
           done
-  validate-notebooks:
-    name: Validate Notebooks
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        # Required for commands to execute *within the conda env*
-        shell: bash -l {0}
-    steps:
       - name: Run notebooks
         run: |
           for nb in notebooks/*.ipynb; do

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,6 @@ jobs:
             activate-environment: uc-python
             environment-file: environment.yml
         - run: |
-            conda env list
-            conda info
-            conda list
-
+            conda activate uc-python
+        - run: |
+            conda install papermill

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,5 +33,6 @@ jobs:
       - name: Run notebooks
         run: |
           for nb in notebooks/*.ipynb; do
-            papermill --cwd notebooks/ $nb - > /dev/null
+            echo "running $nb"
+            output=$(papermill --cwd notebooks/ $nb)
           done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,3 +25,7 @@ jobs:
           for nb in notebooks/*.ipynb; do
             python scripts/prep_nb_for_ci.py $nb
           done
+      - run: |
+          for nb in notebooks/*.ipynb; do
+            papermill $nb > /dev/null
+          done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,15 +14,8 @@ jobs:
           with:
             activate-environment: uc-python
             environment-file: environment.yml
-        - name: Install nbconvert
-          shell: bash -l {0}
-          run:
-            conda install -y nbconvert
-        - name: Convert notebooks to scripts
-          shell: bash -l {0}
-          run: 
-            bash scripts/generate_scripts.sh
-        - name: Run scripts
-          shell: bash -l {0}
-          run:
-            bash scripts/test_nb_scripts.sh
+        - run: |
+            conda env list
+            conda info
+            conda list
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
           environment-file: environment.yml
       - name: Set Up Jupyter Kernel
         run: |
-          python -m ipykernel install --name uc-python
+          python -m ipykernel install --user --name uc-python
       - name: Install Papermill
         run: |
           conda install papermill

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,5 +34,5 @@ jobs:
         run: |
           for nb in notebooks/*.ipynb; do
             echo "running $nb"
-            output=$(papermill --cwd notebooks/ $nb)
+            output=$(papermill --cwd notebooks/ $nb -)
           done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,21 +3,25 @@ name: Test
 on: push
 
 jobs:
-    validate-notebooks:
-      name: Validate Notebooks
-      runs-on: ubuntu-latest
-      defaults:
-        run:
-          shell: bash -l {0}
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
-        - name: Setup Conda Environment
-          uses: conda-incubator/setup-miniconda@v2
-          with:
-            activate-environment: uc-python
-            environment-file: environment.yml
-        - run: |
-            conda install papermill
-        - run: |
-            conda env list
+  validate-notebooks:
+    name: Validate Notebooks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Required for "run" commands to execute in the conda env.
+        shell: bash -l {0}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Conda Environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: uc-python
+          environment-file: environment.yml
+      - run: |
+          conda install papermill
+      - run: |
+          # Remove nb cells that should be skipped in CI.
+          for nb in notebooks/*.ipynb; do
+            python scripts/prep_nb_for_ci.py $nb
+          done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,5 +33,5 @@ jobs:
       - name: Run notebooks
         run: |
           for nb in notebooks/*.ipynb; do
-            papermill $nb - > /dev/null
+            papermill --cwd notebooks/ $nb - > /dev/null
           done

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,9 @@ jobs:
         with:
           activate-environment: uc-python
           environment-file: environment.yml
+      - name: Set Up Jupyter Kernel
+        run: |
+          python -m ipykernel install --name uc-python
       - name: Install Papermill
         run: |
           conda install papermill

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,12 +3,12 @@ name: Test
 on: push
 
 jobs:
-  validate-notebooks:
-    name: Validate Notebooks
+  setup:
+    name: setup
     runs-on: ubuntu-latest
     defaults:
       run:
-        # Required for "run" commands to execute in the conda env.
+        # Required for commands to execute *within the conda env*
         shell: bash -l {0}
     steps:
       - name: Checkout Code
@@ -30,6 +30,14 @@ jobs:
           for nb in notebooks/*.ipynb; do
             python scripts/prep_nb_for_ci.py $nb
           done
+  validate-notebooks:
+    name: Validate Notebooks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # Required for commands to execute *within the conda env*
+        shell: bash -l {0}
+    steps:
       - name: Run notebooks
         run: |
           for nb in notebooks/*.ipynb; do

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,9 @@ jobs:
     validate-notebooks:
       name: Validate Notebooks
       runs-on: ubuntu-latest
+      defaults:
+        run:
+          shell: bash -l {0}
       steps:
         - name: Checkout code
           uses: actions/checkout@v2
@@ -15,6 +18,6 @@ jobs:
             activate-environment: uc-python
             environment-file: environment.yml
         - run: |
-            conda activate uc-python
-        - run: |
             conda install papermill
+        - run: |
+            conda env list

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,21 +11,24 @@ jobs:
         # Required for "run" commands to execute in the conda env.
         shell: bash -l {0}
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v2
-      - name: Setup Conda Environment
+      - name: Set Up Conda Environment
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: uc-python
           environment-file: environment.yml
-      - run: |
+      - name: Install Papermill
+        run: |
           conda install papermill
-      - run: |
+      - name: Prep notebooks
+        run: |
           # Remove nb cells that should be skipped in CI.
           for nb in notebooks/*.ipynb; do
             python scripts/prep_nb_for_ci.py $nb
           done
-      - run: |
+      - name: Run notebooks
+        run: |
           for nb in notebooks/*.ipynb; do
-            papermill $nb > /dev/null
+            papermill $nb - > /dev/null
           done

--- a/notebooks/02-Fundamentals.ipynb
+++ b/notebooks/02-Fundamentals.ipynb
@@ -368,7 +368,10 @@
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": [
+     "ci-skip"
+    ]
    },
    "outputs": [
     {
@@ -922,7 +925,10 @@
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": [
+     "ci-skip"
+    ]
    },
    "outputs": [
     {

--- a/notebooks/03-Packages-Modules-Function.ipynb
+++ b/notebooks/03-Packages-Modules-Function.ipynb
@@ -164,7 +164,10 @@
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": [
+     "ci-skip"
+    ]
    },
    "outputs": [],
    "source": [
@@ -1532,7 +1535,10 @@
    "metadata": {
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": [
+     "ci-skip"
+    ]
    },
    "outputs": [
     {
@@ -2925,7 +2931,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   },
   "rise": {
    "autolaunch": true,

--- a/notebooks/Case-Study-Solutions.ipynb
+++ b/notebooks/Case-Study-Solutions.ipynb
@@ -1511,15 +1511,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/scripts/prep_nb_for_ci.py
+++ b/scripts/prep_nb_for_ci.py
@@ -1,0 +1,31 @@
+# Replace a notebook, with cells tagged ci-skip removed.
+# Adapted from https://stackoverflow.com/questions/62022603/how-to-delete-a-jupyter-notebook-input-cell-programmatically-using-its-tag
+
+import sys
+import nbformat
+
+SKIP_TAG = 'ci-skip'
+
+if len(sys.argv) != 2:
+    raise Exception('Usage: prep_nb_for_ci [notebook.ipynb]')
+nb_file = sys.argv[1]
+
+nb = nbformat.read(nb_file, as_version=nbformat.NO_CONVERT)
+
+tagged_cell_indices = []
+
+# find index for the cell with the injected params
+for idx, cell in enumerate(nb.cells):
+    cell_tags = cell.metadata.get('tags')
+    if cell_tags:
+        if SKIP_TAG in cell_tags:
+            tagged_cell_indices.append(idx)
+
+# Remove tagged cells.
+# Iterate in reverse because deleting an earlier index will change what cell
+# is at a later one.
+for idx in reversed(tagged_cell_indices):
+    nb.cells.pop(idx)
+
+# Overwrite the original.
+nbformat.write(nb, nb_file)


### PR DESCRIPTION
This PR adds GitHub Actions to the repo. The workflow is:
- Check out the code
- Set up the uc-python conda environment (and install required packages)
- Set up a Jupyter kernel to go with that environment
- Install Papermill, which will be used to run the notebooks later
- Prep the notebooks for CI, by removing cells that are tagged "ci-skip" (I added these tags in cells that are *supposed* to fail)
- Run the notebooks with Papermill

The notable new files:
- .github/workflows/test.yaml – the yaml file defining the steps above. Mostly pretty straightforward.
- scripts/prep_nb_for_ci.py – a script I wrote to read in a notebook, remove cells with the "ci-skip" tag, and then save the updated version (overwriting the original). This was the only way I could figure out how to skip certain "expected to fail" cells.

@bradleyboehmke – I'm going to merge this myself but wanted to make sure you saw it. I plan to integrate this in the intermediate repo as well before that training rolls around.