### PR TITLE
Revert to Python 3.11

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - defaults
     - conda-forge
 dependencies:
-    - python=3.12
+    - python=3.11
     - pip>=22.1
     - nbconvert>=6.1
     - numpy=1.26

--- a/notebooks/00-Introduction.ipynb
+++ b/notebooks/00-Introduction.ipynb
@@ -362,7 +362,7 @@
     "### Python\n",
     "\n",
     "* Python is the programming language we'll be learning in this class.\n",
-    "* We are using Python 3.12, the newest version of Python, for the entirety of this class.\n",
+    "* We are using Python 3.11, the (second-)newest version of Python, for the entirety of this class.\n",
     "* The core libaries we will be using are `pandas` and `seaborn`."
    ]
   },


### PR DESCRIPTION
Binder image cannot use 3.12 yet, so downgrading for the moment.