### PR TITLE
Python 3.12 (again)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Test
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   validate-notebooks:

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - defaults
     - conda-forge
 dependencies:
-    - python=3.11
+    - python=3.12
     - pip>=22.1
     - nbconvert>=6.1
     - numpy=1.26

--- a/notebooks/00-Introduction.ipynb
+++ b/notebooks/00-Introduction.ipynb
@@ -362,7 +362,7 @@
     "### Python\n",
     "\n",
     "* Python is the programming language we'll be learning in this class.\n",
-    "* We are using Python 3.11, the newest version of Python, for the entirety of this class.\n",
+    "* We are using Python 3.12, the newest version of Python, for the entirety of this class.\n",
     "* The core libaries we will be using are `pandas` and `seaborn`."
    ]
   },

--- a/notebooks/00-Introduction.ipynb
+++ b/notebooks/00-Introduction.ipynb
@@ -362,7 +362,7 @@
     "### Python\n",
     "\n",
     "* Python is the programming language we'll be learning in this class.\n",
-    "* We are using Python 3.11, the (second-)newest version of Python, for the entirety of this class.\n",
+    "* We are using Python 3.11, the newest version of Python, for the entirety of this class.\n",
     "* The core libaries we will be using are `pandas` and `seaborn`."
    ]
   },


### PR DESCRIPTION
Updates to 3.12, for real this time.

I was able to successfully launch Binder this time - https://mybinder.org/v2/gh/uc-python/intro-python-datasci/python-3.12-redux.

For the upcoming class in October, 3.13.0 will be a couple weeks old, so I think we can hold off a few months until Binder gets support and just stick with 3.12 for that class (and the November intermediate).